### PR TITLE
Remove asset-packagist.org from package server list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,6 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
-        },
-        {
-            "type": "composer",
-            "url": "https://asset-packagist.org"
         },{
             "type": "package",
             "package": {


### PR DESCRIPTION
packagist hosted here are already removed downstream in lightning_media

related: #29 